### PR TITLE
Migrating library to build for .net standard

### DIFF
--- a/src/SoCreate.AspNetCore.DataProtection.ServiceFabric/SoCreate.AspNetCore.DataProtection.ServiceFabric.csproj
+++ b/src/SoCreate.AspNetCore.DataProtection.ServiceFabric/SoCreate.AspNetCore.DataProtection.ServiceFabric.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Jami Lurock</Authors>
     <Company>SoCreate</Company>
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
     <PackageReference Include="SoCreate.Extensions.Caching.ServiceFabric" Version="1.0.7" />
   </ItemGroup>
 

--- a/tests/SoCreate.AspNetCore.DataProtection.Tests/SoCreate.AspNetCore.DataProtection.Tests.csproj
+++ b/tests/SoCreate.AspNetCore.DataProtection.Tests/SoCreate.AspNetCore.DataProtection.Tests.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2;net472</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.8.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />


### PR DESCRIPTION
Moving to .net standard so that .net framework projects may utilize it.

Adding .net framework unit testing.

Resolves #2