### PR TITLE
Updated packages. Removing unicode NULL.

### DIFF
--- a/examples/Services/DataProtectionStore/DataProtectionStore.csproj
+++ b/examples/Services/DataProtectionStore/DataProtectionStore.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="6.0.*" />
-    <PackageReference Include="SoCreate.Extensions.Caching.ServiceFabric" Version="2.*" />
+    <PackageReference Include="SoCreate.Extensions.Caching.ServiceFabric" Version="3.*" />
   </ItemGroup>
 
 </Project>

--- a/src/SoCreate.AspNetCore.DataProtection.ServiceFabric/SoCreate.AspNetCore.DataProtection.ServiceFabric.csproj
+++ b/src/SoCreate.AspNetCore.DataProtection.ServiceFabric/SoCreate.AspNetCore.DataProtection.ServiceFabric.csproj
@@ -19,8 +19,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="5.0.*" />
-    <PackageReference Include="SoCreate.Extensions.Caching.ServiceFabric" Version="2.*" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="6.0.*" />
+    <PackageReference Include="SoCreate.Extensions.Caching.ServiceFabric" Version="3.*" />
   </ItemGroup>
 
 </Project>

--- a/tests/SoCreate.AspNetCore.DataProtection.Tests/SoCreate.AspNetCore.DataProtection.Tests.csproj
+++ b/tests/SoCreate.AspNetCore.DataProtection.Tests/SoCreate.AspNetCore.DataProtection.Tests.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6</TargetFrameworks>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.AutoMoq" Version="4.8.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Since the serialized/deserialized data is interpreted having a UTF-8 encoding, after net6 upgrade XmlSerializer started to throw the error saying that "hexadecimal value 0x00 is a invalid character, line ...". This is why some changes were made in ServiceFabricXmlRepository.cs